### PR TITLE
Fix spacing in fstab

### DIFF
--- a/ramdisk/fstab.villec2
+++ b/ramdisk/fstab.villec2
@@ -1,24 +1,22 @@
 # Android fstab file.
-#<src>			<mnt_point>	<type>	<mnt_flags>						<fs_mgr_flags>
+#<src>			<mnt_point>	<type>  <mnt_flags>						<fs_mgr_flags>
 # load these in early-init instead
-#/dev/block/mmcblk0p17	/vendor/firmware/misc	vfat	ro,shortname=lower				wait
-#/dev/block/mmcblk0p19	/vendor/firmware/adsp	vfat	ro,shortname=lower				wait
+#/dev/block/mmcblk0p17      /vendor/firmware/misc	vfat  ro,shortname=lower            wait
+#/dev/block/mmcblk0p19      /vendor/firmware/adsp	vfat  ro,shortname=lower            wait
 
 
-/dev/block/platform/msm_sdcc.1/by-num/p20	/boot		emmc	defaults						defaults
-/dev/block/platform/msm_sdcc.1/by-num/p21	/recovery	emmc	defaults						defaults
-/dev/block/platform/msm_sdcc.1/by-num/p22	/misc		emmc	defaults						defaults
-/dev/block/platform/msm_sdcc.1/by-num/p25	/devlog	ext4	noatime,nosuid,nodev,barrier=0				wait
-/dev/block/platform/msm_sdcc.1/by-num/p32	/system	ext4	rw,noatime,barrier=0					wait
-/dev/block/platform/msm_sdcc.1/by-num/p33	/cache	ext4	noatime,nosuid,nodev,barrier=0				wait
-/dev/block/platform/msm_sdcc.1/by-num/p33 /cache  f2fs  rw,nosuid,nodev,noatime,nodiratime,inline_xattr,inline_data,flush_merge  wait
-/dev/block/platform/msm_sdcc.1/by-num/p34	/data		ext4	noatime,nosuid,nodev,noauto_da_alloc,barrier=0		wait,encryptable=footer
-/dev/block/platform/msm_sdcc.1/by-num/p34 /data   f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr,inline_data,flush_merge  wait,encryptable=footer
+/dev/block/platform/msm_sdcc.1/by-num/p20     /boot emmc  defaults            defaults
+/dev/block/platform/msm_sdcc.1/by-num/p21     /recovery emmc  defaults            defaults
+/dev/block/platform/msm_sdcc.1/by-num/p22     /misc emmc  defaults            defaults
+/dev/block/platform/msm_sdcc.1/by-num/p25     /devlog ext4  noatime,nosuid,nodev,barrier=0            wait
+/dev/block/platform/msm_sdcc.1/by-num/p32     /system ext4  rw,noatime,barrier=0            wait
+/dev/block/platform/msm_sdcc.1/by-num/p33     /cache  ext4  noatime,nosuid,nodev,barrier=0            wait
+/dev/block/platform/msm_sdcc.1/by-num/p33     /cache  f2fs  rw,nosuid,nodev,noatime,nodiratime,inline_xattr,inline_data,flush_merge           wait
+/dev/block/platform/msm_sdcc.1/by-num/p34     /data ext4  noatime,nosuid,nodev,noauto_da_alloc,barrier=0            wait,encryptable=footer
+/dev/block/platform/msm_sdcc.1/by-num/p34     /data f2fs  rw,nosuid,nodev,noatime,nodiratime,inline_xattr,inline_data,flush_merge           wait,encryptable=footer
 
-
-
-/devices/platform/msm_sdcc.1/mmc_host/mmc0  auto  auto  defaults        voldmanaged=sdcard0:35,noemulatedsd
+# SD Card
+/devices/platform/msm_sdcc.1/mmc_host/mmc0      auto  auto  defaults            voldmanaged=sdcard0:35,noemulatedsd
 
 # USB storage
-/devices/platform/msm_hsusb_host/usb  auto  auto  defaults      voldmanaged=usbdisk:auto
-
+/devices/platform/msm_hsusb_host/usb      auto  auto  defaults            voldmanaged=usbdisk:auto


### PR DESCRIPTION
This is now linux standard formatting based on the second line's spacing
