### PR TITLE
Add the new kernel repo as dependency.

### DIFF
--- a/cm.dependencies
+++ b/cm.dependencies
@@ -1,6 +1,6 @@
 [
   {
-    "repository": "android_kernel_htc_villec2",
+    "repository": "villec2-kernel",
     "target_path": "kernel/htc/villec2"
   }
 ]


### PR DESCRIPTION
"android_kernel_htc_liberty-villec2" is obsolete, so it shouldn't be a dependency.
